### PR TITLE
Always print argument descriptions, event if options not present

### DIFF
--- a/core/src/main/scala/org/backuity/clist/Usage.scala
+++ b/core/src/main/scala/org/backuity/clist/Usage.scala
@@ -137,11 +137,11 @@ object Usage {
               indent {
                 addOptions(commandSpecificOpts)
               }
-              val commandSpecificArgs = command.arguments
-              if (commandSpecificArgs.nonEmpty) {
-                indent {
-                  addArguments(commandSpecificArgs)
-                }
+            }
+            val commandSpecificArgs = command.arguments
+            if (commandSpecificArgs.nonEmpty) {
+              indent {
+                addArguments(commandSpecificArgs)
               }
             }
           }


### PR DESCRIPTION
A fix for https://github.com/backuity/clist/issues/31